### PR TITLE
Remove all unsupported layers and iteratively fix all layers

### DIFF
--- a/src/photon/application/dialogs/FixDialog.form
+++ b/src/photon/application/dialogs/FixDialog.form
@@ -3,12 +3,12 @@
   <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="48" y="54" width="810" height="297"/>
+      <xy x="48" y="54" width="810" height="315"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -18,13 +18,13 @@
         <children>
           <hspacer id="98af6">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
           <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -39,6 +39,24 @@
               </component>
             </children>
           </grid>
+          <component id="7b492" class="javax.swing.JButton" binding="removeUnsupportedButton">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Remove unsupported"/>
+              <toolTipText value="Remove all unsupported islands from all layers"/>
+            </properties>
+          </component>
+          <component id="c3190" class="javax.swing.JButton" binding="fixAllButton">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Fix all"/>
+              <toolTipText value="Fix all layers, then remove all left unsupported layers, then repeat until everything is fixed"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <grid id="e3588" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/photon/application/dialogs/FixDialog.java
+++ b/src/photon/application/dialogs/FixDialog.java
@@ -28,7 +28,9 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.uiDesigner.core.Spacer;
 import photon.application.MainForm;
+import photon.application.utilities.PhotonFixAllWorker;
 import photon.application.utilities.PhotonFixWorker;
+import photon.application.utilities.PhotonRemoveAllIslandsWorker;
 import photon.file.PhotonFile;
 import photon.file.parts.PhotonFileLayer;
 
@@ -42,7 +44,9 @@ public class FixDialog extends JDialog {
     public JButton buttonOK;
     private JScrollPane textPane;
     public JButton startButton;
+    public JButton fixAllButton;
     private JLabel progressInfo;
+    private JButton removeUnsupportedButton;
 
     private FixDialog me;
     private MainForm mainForm;
@@ -59,18 +63,51 @@ public class FixDialog extends JDialog {
         getRootPane().setDefaultButton(buttonOK);
 
         buttonOK.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {onOK();}
+            public void actionPerformed(ActionEvent e) {
+                onOK();
+            }
         });
 
         startButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 startButton.setEnabled(false);
+                fixAllButton.setEnabled(false);
+                removeUnsupportedButton.setEnabled(false);
                 buttonOK.setEnabled(false);
                 PhotonFixWorker photonFixWorker = new PhotonFixWorker(me, mainForm.photonFile, mainForm);
                 photonFixWorker.execute();
             }
         });
 
+        fixAllButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                startButton.setEnabled(false);
+                fixAllButton.setEnabled(false);
+                removeUnsupportedButton.setEnabled(false);
+                buttonOK.setEnabled(false);
+                PhotonFixAllWorker photonFixWorker = new PhotonFixAllWorker(me, mainForm.photonFile, mainForm);
+                photonFixWorker.execute();
+            }
+        });
+
+        removeUnsupportedButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                startButton.setEnabled(false);
+                fixAllButton.setEnabled(false);
+                removeUnsupportedButton.setEnabled(false);
+                buttonOK.setEnabled(false);
+                PhotonRemoveAllIslandsWorker photonFixWorker = new PhotonRemoveAllIslandsWorker(me, mainForm.photonFile, mainForm);
+                photonFixWorker.execute();
+            }
+        });
+
+    }
+
+    public void enableButtons() {
+        buttonOK.setEnabled(true);
+        startButton.setEnabled(true);
+        fixAllButton.setEnabled(true);
+        removeUnsupportedButton.setEnabled(true);
     }
 
     private void onOK() {
@@ -128,42 +165,52 @@ public class FixDialog extends JDialog {
      */
     private void $$$setupUI$$$() {
         contentPane = new JPanel();
-        contentPane.setLayout(new com.intellij.uiDesigner.core.GridLayoutManager(3, 1, new Insets(10, 10, 10, 10), -1, -1));
+        contentPane.setLayout(new GridLayoutManager(3, 1, new Insets(10, 10, 10, 10), -1, -1));
         final JPanel panel1 = new JPanel();
-        panel1.setLayout(new com.intellij.uiDesigner.core.GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
-        contentPane.add(panel1, new com.intellij.uiDesigner.core.GridConstraints(2, 0, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_BOTH, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
-        final com.intellij.uiDesigner.core.Spacer spacer1 = new com.intellij.uiDesigner.core.Spacer();
-        panel1.add(spacer1, new com.intellij.uiDesigner.core.GridConstraints(0, 0, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_HORIZONTAL, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
+        panel1.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
+        contentPane.add(panel1, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
+        final Spacer spacer1 = new Spacer();
+        panel1.add(spacer1, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
         final JPanel panel2 = new JPanel();
-        panel2.setLayout(new com.intellij.uiDesigner.core.GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
-        panel1.add(panel2, new com.intellij.uiDesigner.core.GridConstraints(0, 1, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_BOTH, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        panel2.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
+        panel1.add(panel2, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         buttonOK = new JButton();
         buttonOK.setText("OK");
-        panel2.add(buttonOK, new com.intellij.uiDesigner.core.GridConstraints(0, 0, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_HORIZONTAL, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel2.add(buttonOK, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        removeUnsupportedButton = new JButton();
+        removeUnsupportedButton.setText("Remove unsupported");
+        removeUnsupportedButton.setToolTipText("Remove all unsupported islands from all layers");
+        panel1.add(removeUnsupportedButton, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        fixAllButton = new JButton();
+        fixAllButton.setText("Fix all");
+        fixAllButton.setToolTipText("Fix all layers, then remove all left unsupported layers, then repeat until everything is fixed");
+        panel1.add(fixAllButton, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel3 = new JPanel();
-        panel3.setLayout(new com.intellij.uiDesigner.core.GridLayoutManager(1, 1, new Insets(0, 5, 5, 5), -1, -1));
-        contentPane.add(panel3, new com.intellij.uiDesigner.core.GridConstraints(1, 0, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_BOTH, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        panel3.setLayout(new GridLayoutManager(1, 1, new Insets(0, 5, 5, 5), -1, -1));
+        contentPane.add(panel3, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         textPane = new JScrollPane();
-        panel3.add(textPane, new com.intellij.uiDesigner.core.GridConstraints(0, 0, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_BOTH, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_WANT_GROW, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(480, 200), new Dimension(480, 200), null, 0, false));
+        panel3.add(textPane, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(480, 200), new Dimension(480, 200), null, 0, false));
         progressInfo = new JLabel();
         progressInfo.setText("");
         progressInfo.setVerticalAlignment(1);
         progressInfo.setVerticalTextPosition(1);
         textPane.setViewportView(progressInfo);
         final JPanel panel4 = new JPanel();
-        panel4.setLayout(new com.intellij.uiDesigner.core.GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
-        contentPane.add(panel4, new com.intellij.uiDesigner.core.GridConstraints(0, 0, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_BOTH, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        panel4.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
+        contentPane.add(panel4, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final JLabel label1 = new JLabel();
         label1.setText("Try to fix minor errors, where pixels only connects by the corners or the space between pixels is only one pixel.");
-        panel4.add(label1, new com.intellij.uiDesigner.core.GridConstraints(0, 0, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_WEST, com.intellij.uiDesigner.core.GridConstraints.FILL_NONE, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        panel4.add(label1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         startButton = new JButton();
         startButton.setText("Start");
-        panel4.add(startButton, new com.intellij.uiDesigner.core.GridConstraints(0, 1, 1, 1, com.intellij.uiDesigner.core.GridConstraints.ANCHOR_CENTER, com.intellij.uiDesigner.core.GridConstraints.FILL_HORIZONTAL, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_SHRINK | com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_CAN_GROW, com.intellij.uiDesigner.core.GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel4.add(startButton, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
     }
 
     /**
      * @noinspection ALL
      */
-    public JComponent $$$getRootComponent$$$() { return contentPane; }
+    public JComponent $$$getRootComponent$$$() {
+        return contentPane;
+    }
 
 }

--- a/src/photon/application/utilities/PhotonFixAllWorker.java
+++ b/src/photon/application/utilities/PhotonFixAllWorker.java
@@ -34,12 +34,12 @@ import javax.swing.*;
 /**
  * by bn on 14/07/2018.
  */
-public class PhotonFixWorker extends SwingWorker<Integer, String> implements IPhotonProgress {
+public class PhotonFixAllWorker extends SwingWorker<Integer, String> implements IPhotonProgress {
     private FixDialog fixDialog;
     private PhotonFile photonFile;
     private MainForm mainForm;
 
-    public PhotonFixWorker(FixDialog fixDialog, PhotonFile photonFile, MainForm mainForm) {
+    public PhotonFixAllWorker(FixDialog fixDialog, PhotonFile photonFile, MainForm mainForm) {
         this.fixDialog = fixDialog;
         this.photonFile = photonFile;
         this.mainForm = mainForm;
@@ -67,7 +67,7 @@ public class PhotonFixWorker extends SwingWorker<Integer, String> implements IPh
     @Override
     protected Integer doInBackground() throws Exception {
         try {
-            photonFile.fixLayers(this);
+            photonFile.fixAll(this);
         } catch (Exception e) {
             publish("<br><p>" + e.getMessage()+ "</p>");
             return 0;

--- a/src/photon/application/utilities/PhotonRemoveAllIslandsWorker.java
+++ b/src/photon/application/utilities/PhotonRemoveAllIslandsWorker.java
@@ -34,12 +34,12 @@ import javax.swing.*;
 /**
  * by bn on 14/07/2018.
  */
-public class PhotonFixWorker extends SwingWorker<Integer, String> implements IPhotonProgress {
+public class PhotonRemoveAllIslandsWorker extends SwingWorker<Integer, String> implements IPhotonProgress {
     private FixDialog fixDialog;
     private PhotonFile photonFile;
     private MainForm mainForm;
 
-    public PhotonFixWorker(FixDialog fixDialog, PhotonFile photonFile, MainForm mainForm) {
+    public PhotonRemoveAllIslandsWorker(FixDialog fixDialog, PhotonFile photonFile, MainForm mainForm) {
         this.fixDialog = fixDialog;
         this.photonFile = photonFile;
         this.mainForm = mainForm;
@@ -67,7 +67,7 @@ public class PhotonFixWorker extends SwingWorker<Integer, String> implements IPh
     @Override
     protected Integer doInBackground() throws Exception {
         try {
-            photonFile.fixLayers(this);
+            photonFile.removeAllIslands(this);
         } catch (Exception e) {
             publish("<br><p>" + e.getMessage()+ "</p>");
             return 0;

--- a/src/photon/file/PhotonFile.java
+++ b/src/photon/file/PhotonFile.java
@@ -352,8 +352,57 @@ public class PhotonFile {
             layer.setLayerOffTimeSeconds(iFileHeader.getOffTimeSeconds());
         }
     }
+    
+    public void fixAll(IPhotonProgress progres) throws Exception {
+    	boolean layerWasFixed = false;
+    	do {
+    		do {
+    			// Repeatedly fix layers until none are possible to fix
+    			// Fixing some layers can make other layers auto-fixable
+    			layerWasFixed = fixLayers(progres);
+    		} while(layerWasFixed);
+	    	if(islandLayers.size() > 0) {
+	    		// Nothing can be done further, just remove all layers left
+	    		layerWasFixed = removeAllIslands(progres) || layerWasFixed;
+	    	}
+	    	if(layerWasFixed && islandLayers.size() > 0) {
+	    		// We could've created new islands by removing islands, repeat fixing process
+	    		// until everything is fixed or nothing can be done
+    			progres.showInfo("<br>Some layers were fixed, but " + islandLayers.size() + " still unsupported, repeating...<br>");
+    		}
+    	} while(layerWasFixed);
+    }
+    
+    public boolean removeAllIslands(IPhotonProgress progres) throws Exception {
+    	boolean layersFixed = false;
+    	progres.showInfo("Removing all leftover " + islandLayers.size() + " islands...<br>");
+		PhotonLayer layer = null;
+		for (int layerNo : islandLayers) {
+	        PhotonFileLayer fileLayer = layers.get(layerNo);
+	        if (layer == null) {
+                layer = fileLayer.getLayer();
+            } else {
+                fileLayer.getUpdateLayer(layer);
+            }
+            progres.showInfo("Removing islands from layer " + layerNo);
 
-    public void fixLayers(IPhotonProgress progres) throws Exception {
+	        int removed = layer.removeIslands();
+	        if(removed == 0) {
+	        	progres.showInfo(", but nothing could be done.");
+	        } else {
+	        	progres.showInfo(", " + removed + " islands removed");
+	            fileLayer.saveLayer(layer);
+		            calculate(layerNo);
+		            layersFixed = true;
+	        }
+	        progres.showInfo("<br>");
+		}
+		findIslands();
+		return layersFixed;
+    }
+
+    public boolean fixLayers(IPhotonProgress progres) throws Exception {
+    	boolean layersFixed = false;
         PhotonLayer layer = null;
         for (int layerNo : islandLayers) {
             progres.showInfo("Checking layer " + layerNo);
@@ -372,12 +421,14 @@ public class PhotonFile {
             } else {
                 fileLayer.saveLayer(layer);
                 calculate(layerNo);
+                layersFixed = true;
             }
 
             progres.showInfo("<br>");
 
         }
         findIslands();
+        return layersFixed;
     }
 
     private int fixit(IPhotonProgress progres, PhotonLayer layer, PhotonFileLayer fileLayer, int loops) throws Exception {

--- a/src/photon/file/PhotonFile.java
+++ b/src/photon/file/PhotonFile.java
@@ -375,7 +375,7 @@ public class PhotonFile {
     
     public boolean removeAllIslands(IPhotonProgress progres) throws Exception {
     	boolean layersFixed = false;
-    	progres.showInfo("Removing all leftover " + islandLayers.size() + " islands...<br>");
+    	progres.showInfo("Removing islands from " + islandLayers.size() + " layers...<br>");
 		PhotonLayer layer = null;
 		for (int layerNo : islandLayers) {
 	        PhotonFileLayer fileLayer = layers.get(layerNo);
@@ -392,8 +392,8 @@ public class PhotonFile {
 	        } else {
 	        	progres.showInfo(", " + removed + " islands removed");
 	            fileLayer.saveLayer(layer);
-		            calculate(layerNo);
-		            layersFixed = true;
+	            calculate(layerNo);
+	            layersFixed = true;
 	        }
 	        progres.showInfo("<br>");
 		}

--- a/src/photon/file/PhotonFile.java
+++ b/src/photon/file/PhotonFile.java
@@ -393,6 +393,9 @@ public class PhotonFile {
 	        	progres.showInfo(", " + removed + " islands removed");
 	            fileLayer.saveLayer(layer);
 	            calculate(layerNo);
+	            if (layerNo < getLayerCount() - 1) {
+                    calculate(layerNo + 1);
+                }
 	            layersFixed = true;
 	        }
 	        progres.showInfo("<br>");
@@ -421,6 +424,9 @@ public class PhotonFile {
             } else {
                 fileLayer.saveLayer(layer);
                 calculate(layerNo);
+                if (layerNo < getLayerCount() - 1) {
+                    calculate(layerNo + 1);
+                }
                 layersFixed = true;
             }
 


### PR DESCRIPTION
This change adds two buttons to the Fix panel:
* Remove unsupported - removes all unsupported islands from all layers
* Fix all - performs Fix layers operation until none layers are changed, then removes all left unsupported islands and repeats and repeats until everything is fixed or nothing is fixable

Idk if it breaks the purpose of the validator, but sometimes it's really tedious fixing this by hand... The "Fix all" button takes a really long time to finish, maybe there is a need for more clarity during the process.

Implements https://github.com/Photonsters/PhotonFileValidator/issues/25